### PR TITLE
fix: crash when the api is unavailable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,11 @@ module.exports = (cnpj, token) => {
     })
       .then((response) => resolve(response.data))
       .catch((error) => {
-        reject(error.response.data);
+        if(error.response && error.response.data){
+          reject(error.response.data);
+        } else {
+          reject(error);
+        }
       });
   });
 };
@@ -48,7 +52,11 @@ module.exports.raiz = (raiz, token, options = { page: 1 }) => {
     })
       .then((response) => resolve(response.data))
       .catch((error) => {
-        reject(error.response.data);
+        if(error.response && error.response.data){
+          reject(error.response.data);
+        } else {
+          reject(error);
+        }
       });
   });
 };
@@ -70,7 +78,11 @@ module.exports.consumo = (token, ano, mes) => {
     })
       .then((response) => resolve(response.data.data))
       .catch((error) => {
-        reject(error.response.data);
+        if(error.response && error.response.data){
+          reject(error.response.data);
+        } else {
+          reject(error);
+        }
       });
   });
 };
@@ -113,7 +125,11 @@ module.exports.pesquisa = (filtros = null, token, page = 1, limite = 100) => {
     })
       .then((response) => resolve(response.data))
       .catch((error) => {
-        reject(error.response.data);
+        if(error.response && error.response.data){
+          reject(error.response.data);
+        } else {
+          reject(error);
+        }
       });
   });
 };
@@ -142,7 +158,11 @@ module.exports.suframa = (cnpj,inscricao, token) => {
     })
       .then((response) => resolve(response.data))
       .catch((error) => {
-        reject(error.response.data);
+        if(error.response && error.response.data){
+          reject(error.response.data);
+        } else {
+          reject(error);
+        }
       });
   });
 };


### PR DESCRIPTION
# Tratamento de erro quando a API está fora do ar

Olá,

Encontrei um problema na biblioteca onde, se a API usada para consultar o CNPJ estiver fora do ar ou a aplicação que estava fazendo uso tenha algum problema de rede ao fazer a consulta, a biblioteca lança uma exceção não tratada que pode levar a um crash na aplicação.

O problema ocorre porque a biblioteca tenta acessar a propriedade 'data' de 'error.response', que é indefinida quando a API está indisponível. Isso resulta em um TypeError.

Fiz uma alteração para verificar se 'error.response' e 'error.response.data' existem antes de tentar acessá-los. Isso evita o TypeError e permite que a aplicação lide com o erro de maneira mais apropriada.

Aqui está o código atualizado:

<pre><code class="hljs language-javascript">.<span class="hljs-title function_">catch</span>(<span class="hljs-function">(<span class="hljs-params">error</span>) =&gt;</span> {
    <span class="hljs-keyword">if</span> (error.<span class="hljs-property">response</span> &amp;&amp; error.<span class="hljs-property">response</span>.<span class="hljs-property">data</span>) {
        <span class="hljs-title function_">reject</span>(error.<span class="hljs-property">response</span>.<span class="hljs-property">data</span>);
    } <span class="hljs-keyword">else</span> {
        <span class="hljs-title function_">reject</span>(error);
    }
});

</code></pre>
Espero que isso seja útil e aguardo seus comentários.

Atenciosamente, Filipe Vieira